### PR TITLE
Add support for nuget index feeds and automatic service resolving

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
   // enforcing options
-  "esversion": 6,
+  "esversion": 9,
   "asi": true,        // relax semicolons
   "varstmt": true,    // no var's'
   "laxbreak": true,   // allow conditionals after line breaks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.25.1
+
+  - Dotnet: Add more service resolvers.
+
+# 0.25.0
+
+  - Dotnet: Migrate from strict SearchAutocompleteService requirement to support multiple methods that are resolved automatically from feed index.
+
 # 0.24.0
 
   - Dart+Flutter support added (thanks to https://github.com/Gorniv)

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2019 Ignas Maslinskas
 Copyright (c) Peter Flannery
 
 All rights reserved. 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Shows package version information for npm, jspm, dub and dotnet core in the [Visual Studio Code](https://github.com/microsoft/vscode) editor.
 
+This version contains extended dotnet support.
+
 Originally by Peter Flannery at https://github.com/vscode-contrib/vscode-versionlens.
 
 ### Preview

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Shows package version information for npm, jspm, dub and dotnet core in the [Visual Studio Code](https://github.com/microsoft/vscode) editor.
 
+Originally by Peter Flannery at https://github.com/vscode-contrib/vscode-versionlens.
+
 ### Preview
 
 ![Screenshot](images/animated-preview.gif)

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "vscode-versionlens",
   "private": true,
-  "description": "Shows the latest version for each package using code lens",
+  "description": "Shows the latest version for each package using code lens. Fork of https://github.com/vscode-contrib/vscode-versionlens.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/vscode-contrib/vscode-versionlens.git"
+    "url": "https://github.com/hoffs/vscode-versionlens.git"
   },
-  "author": "Peter Flannery",
+  "author": "Ignas Maslinskas",
   "license": "MIT",
-  "version": "0.24.0",
-  "publisher": "pflannery",
+  "version": "0.25.0",
+  "publisher": "Hoffs",
   "displayName": "Version Lens",
   "icon": "images/logo.png",
   "engines": {
@@ -287,15 +287,15 @@
           "default": [],
           "description": "Define which common tagged versions you want to see. i.e. [alpha, beta]. If you don't specify any dist tags then all the dist-tags for a package will be shown."
         },
-        "versionlens.dotnet.nugetFeeds": {
+        "versionlens.dotnet.nugetIndexes": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [
-            "https://api-v2v3search-0.nuget.org/autocomplete"
+            "https://api.nuget.org/v3/index.json"
           ],
-          "description": "Defines which NuGet feeds to use for package search. Has to be 'SearchAutocompleteService' endpoint, which can be found by navigating to feed index (e.g. https://api.nuget.org/v3/index.json) and looking for Url with that type."
+          "description": "Defines which NuGet feeds to use for package search. Has to be feed index (e.g. https://api.nuget.org/v3/index.json)."
         },
         "versionlens.dotnet.includePrerelease": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Ignas Maslinskas",
   "license": "MIT",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "publisher": "Hoffs",
   "displayName": "Version Lens",
   "icon": "images/logo.png",

--- a/src/common/appContrib.js
+++ b/src/common/appContrib.js
@@ -7,7 +7,7 @@ import { pubDefaultDependencyProperties } from 'providers/pub/config';
 import { dubDefaultDependencyProperties } from 'providers/dub/config';
 import {
   dotnetCSProjDefaultDependencyProperties,
-  dotnetDefaultNuGetFeeds
+  dotnetDefaultNuGetIndexes
 } from 'providers/dotnet/config';
 import {
   mavenDefaultDependencyProperties
@@ -62,9 +62,9 @@ export default new class AppContribution {
     return config.get("dotnet.tagFilter", []);
   }
 
-  get dotnetNuGetFeeds() {
+  get dotnetNuGetIndexes() {
     const config = workspace.getConfiguration('versionlens');
-    return config.get("dotnet.nugetFeeds", dotnetDefaultNuGetFeeds);
+    return config.get("dotnet.nugetIndexes", dotnetDefaultNuGetIndexes);
   }
 
   get dotnetIncludePrerelease() {

--- a/src/providers/dotnet/config.js
+++ b/src/providers/dotnet/config.js
@@ -7,6 +7,6 @@ export const dotnetCSProjDefaultDependencyProperties = [
   "DotNetCliToolReference"
 ];
 
-export const dotnetDefaultNuGetFeeds = [
-  "https://api-v2v3search-0.nuget.org/autocomplete"
+export const dotnetDefaultNuGetIndexes = [
+  "https://api.nuget.org/v3/index.json"
 ];

--- a/src/providers/dotnet/nugetClient.js
+++ b/src/providers/dotnet/nugetClient.js
@@ -117,6 +117,31 @@ async function getRegistrationBaseUrlPageVersions(pageUrl) {
   return versions;
 }
 
+// This is a required NugetV3 api
+// Uses SearchQueryService API
+async function getNugetVersionsFromSearchQueryService(serviceUrl, packageName) {
+  const httpRequest = require('request-light');
+
+  // This could take more than 1 and try to search out of those, but for now just assume that first returned entry will be the most correct.
+  const queryUrl = `${serviceUrl}?q=${packageName}&prerelease=${appContrib.dotnetIncludePrerelease}&semVerLevel=2.0.0&skip=0&take=1`;
+  const response = await httpRequest.xhr({ url: queryUrl });
+
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
+
+  const { totalHits, data } = JSON.parse(response.responseText);
+  if (totalHits === 0 || data[0].id.toLowerCase() !== packageName.toLowerCase()) {
+    throw { status: 404 };
+  } else {
+    const versions = data[0].versions.map(v => v.version);
+    return versions.reverse();
+  }
+}
+
 // From https://docs.microsoft.com/en-us/nuget/api/overview
 // Sorted in order that we want to get them.
 const nugetServiceResolvers = [
@@ -129,6 +154,9 @@ const nugetServiceResolvers = [
   { type: 'RegistrationsBaseUrl/3.0.0-rc', resolver: getNugetVersionsFromRegistrationsBaseUrl },
   { type: 'RegistrationsBaseUrl/3.4.0', resolver: getNugetVersionsFromRegistrationsBaseUrl },
   { type: 'RegistrationsBaseUrl/3.6.0', resolver: getNugetVersionsFromRegistrationsBaseUrl },
+  { type: 'SearchQueryService', resolver: getNugetVersionsFromSearchQueryService },
+  { type: 'SearchQueryService/3.0.0-beta', resolver: getNugetVersionsFromSearchQueryService },
+  { type: 'SearchQueryService/3.0.0-rc', resolver: getNugetVersionsFromSearchQueryService },
 ];
 
 async function getVersionResolverFromIndex(index) {

--- a/src/providers/dotnet/nugetClient.js
+++ b/src/providers/dotnet/nugetClient.js
@@ -1,46 +1,155 @@
 /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2019 Ignas Maslinskas. All rights reserved.
  *  Copyright (c) Peter Flannery. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import appContrib from 'common/appContrib';
 const semver = require('semver');
 
-export function nugetGetPackageVersions(packageName) {
+// This is an optional NugetV3 api
+// Uses SearchAutocompleteService API
+async function getNugetVersionsFromSearchAutocompleteService(serviceUrl, packageName) {
   const httpRequest = require('request-light');
-
-  const promises = appContrib.dotnetNuGetFeeds.map(feed => {
-    const queryUrl = `${feed}?id=${packageName}&prerelease=${appContrib.dotnetIncludePrerelease}&semVerLevel=2.0.0`;
-    return new Promise(function (resolve, reject) {
-      httpRequest.xhr({ url: queryUrl })
-        .then(response => {
-          if (response.status != 200) {
-            reject({
-              status: response.status,
-              responseText: response.responseText
-            });
-            return;
-          }
+  const queryUrl = `${serviceUrl}?id=${packageName}&prerelease=${appContrib.dotnetIncludePrerelease}&semVerLevel=2.0.0`;
+  const response = await httpRequest.xhr({ url: queryUrl }); 
   
-          const pkg = JSON.parse(response.responseText);
-          if (pkg.totalHits == 0)
-            reject({ status: 404 });
-          else
-            resolve(pkg.data.reverse());
-        }).catch(reject);
-    });
-  })
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
 
-  return Promise.all(promises.map(p => {
+  const pkg = JSON.parse(response.responseText);
+  if (pkg.totalHits == 0) {
+    throw { status: 404 };
+  } else {
+    return pkg.data.reverse();
+  }
+}
+
+// This is a required NugetV3 api
+// Uses PackageBaseAddress API
+async function getNugetVersionsFromPackageBaseAddress(serviceUrl, packageName) {
+  const httpRequest = require('request-light');
+  // From SearchAutocompleteService
+  if (!serviceUrl.endsWith('/')) {
+    serviceUrl = `${serviceUrl}/`;
+  }
+
+  const queryUrl = `${serviceUrl}${packageName.toLowerCase()}/index.json`;
+  const response = await httpRequest.xhr({ url: queryUrl });
+
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
+
+  const data = JSON.parse(response.responseText);
+  if (!data.versions) {
+    throw { status: 404 };
+  } else {
+    
+    if (!appContrib.dotnetIncludePrerelease) {
+      // If we don't want pre-release, filter out versions which don't have -
+      data.versions = data.versions.filter(ver => ver.indexOf("-") === -1);
+    }
+
+    if (data.versions.length === 0) {
+      throw { status: 404 };
+    }
+
+    return data.versions.reverse();
+  }
+}
+
+// From https://docs.microsoft.com/en-us/nuget/api/overview
+// Sorted in order that we want to get them.
+const nugetServiceResolvers = [
+  { type: 'PackageBaseAddress/3.0.0', resolver: getNugetVersionsFromPackageBaseAddress },
+  { type: 'SearchAutocompleteService', resolver: getNugetVersionsFromSearchAutocompleteService },
+  { type: 'SearchAutocompleteService/3.0.0-beta', resolver: getNugetVersionsFromSearchAutocompleteService },
+  { type: 'SearchAutocompleteService/3.0.0-rc', resolver: getNugetVersionsFromSearchAutocompleteService }
+];
+
+async function getVersionResolverFromIndex(index) {
+  const httpRequest = require('request-light');
+  const indexResponse = await httpRequest.xhr({ url: index });
+
+  if (indexResponse.status != 200) {
+    throw {
+      status: indexResponse.status,
+      responseText: indexResponse.responseText
+    };
+  }
+
+  const indexData = JSON.parse(indexResponse.responseText);
+
+  // Go through the list with each resolver, as we prefer to get a resolver
+  // that is towards the start of the service resolver list.
+  // More efficient would be to just pick first acceptable resolver, but thats not ideal.
+  for (const serviceResolver of nugetServiceResolvers) {
+    for (const resource of indexData.resources) {
+      if (resource['@type'] === serviceResolver.type) {
+        return { index, url: resource['@id'], ...serviceResolver }; // return index + url + resolver
+      }
+    }
+  }
+
+  throw { status: 404, responseText: 'No services with available resolvers found in nuget indexes.' };
+}
+
+async function getAvailableResolvers() {
+  const promises = appContrib.dotnetNuGetIndexes.map(getVersionResolverFromIndex);
+
+  // Remap error'ed as resolved.
+  const resolved = promises.map(p => {
     return p.then(
       result => Promise.resolve(result),
       error => Promise.resolve(error)
     );
-  })).then(
-    results => {
-      const dataResults = results.filter(result => Array.isArray(result)).sort((a, b) => semver.gt(a[0], b[0])); // Filter arrays and sort by first/highest version
-      if (dataResults.length === 0) return Promise.reject(results[0]); // If no arrays, no successful resolves
-      return Promise.resolve(dataResults[0]);
-    },
-    _ => Promise.reject({ status: 404 })
-  )
+  });
+
+  try {
+    const results = await Promise.all(resolved);
+    const availableResolvers = results.filter(r => r.resolver !== undefined);
+
+    if (availableResolvers.length == 0) {
+      throw { status: 404 };
+    }
+
+    // return a list of just resolver closures.
+    return availableResolvers.map(resolver => (packageName) => resolver.resolver(resolver.url, packageName));
+  } catch (error) {
+    throw { status: 404 };
+  }
+}
+
+export async function nugetGetPackageVersions(packageName) {
+  const resolvers = await getAvailableResolvers();
+  const versionPromises = resolvers.map(resolver => resolver(packageName));
+
+  // Remap error'ed as resolved.
+  const resolved = versionPromises.map(p => {
+    return p.then(
+      result => Promise.resolve(result),
+      error => Promise.resolve(error)
+    );
+  });
+
+  try {
+    const results = await Promise.all(resolved);
+    const dataResults = results.filter(result => Array.isArray(result)).sort((a, b) => semver.gt(a[0], b[0])); // Filter arrays and sort by first/highest version
+
+    // If no results assume no successful resolves.
+    if (dataResults.length === 0) {
+      throw results[0];
+    }
+
+    return dataResults[0];
+  } catch (error) {
+    throw { status: 404 };
+  }  
 }

--- a/src/providers/dotnet/nugetResolvers/packageBaseAddressResolver.js
+++ b/src/providers/dotnet/nugetResolvers/packageBaseAddressResolver.js
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2019 Ignas Maslinskas. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import appContrib from 'common/appContrib';
+
+// This is a required NugetV3 api
+// Uses PackageBaseAddress API
+export async function packageBaseAddressResolver(serviceUrl, packageName) {
+  const httpRequest = require('request-light');
+  // From SearchAutocompleteService
+  if (!serviceUrl.endsWith('/')) {
+    serviceUrl = `${serviceUrl}/`;
+  }
+
+  const queryUrl = `${serviceUrl}${packageName.toLowerCase()}/index.json`;
+  const response = await httpRequest.xhr({ url: queryUrl });
+
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
+
+  const data = JSON.parse(response.responseText);
+  if (!data.versions) {
+    throw { status: 404 };
+  } else {
+    
+    if (!appContrib.dotnetIncludePrerelease) {
+      // If we don't want pre-release, filter out versions which don't have -
+      data.versions = data.versions.filter(ver => ver.indexOf("-") === -1);
+    }
+
+    if (data.versions.length === 0) {
+      throw { status: 404 };
+    }
+
+    return data.versions.reverse();
+  }
+}

--- a/src/providers/dotnet/nugetResolvers/registrationsBaseUrlResolver.js
+++ b/src/providers/dotnet/nugetResolvers/registrationsBaseUrlResolver.js
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2019 Ignas Maslinskas. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import appContrib from 'common/appContrib';
+ 
+// This is a required NugetV3 api
+// Uses RegistrationsBaseUrl API
+export async function registrationsBaseUrlResolver(serviceUrl, packageName) {
+  const httpRequest = require('request-light');
+  // From SearchAutocompleteService
+  if (!serviceUrl.endsWith('/')) {
+    serviceUrl = `${serviceUrl}/`;
+  }
+
+  const queryUrl = `${serviceUrl}${packageName.toLowerCase()}/index.json`;
+  const response = await httpRequest.xhr({ url: queryUrl });
+
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
+
+  const data = JSON.parse(response.responseText);
+  if (data.count === 0) {
+    throw { status: 404 };
+  } else {
+    const promises = data.items.filter(item => item['@type'] == 'catalog:CatalogPage').map(item => getRegistrationBaseUrlPageVersions(item['@id']));
+    const results = await Promise.all(promises);
+    return [].concat(...results).sort().reverse();
+  }
+}
+
+async function getRegistrationBaseUrlPageVersions(pageUrl) {
+  const httpRequest = require('request-light');
+  const { status, responseText } = await httpRequest.xhr({ url: pageUrl });
+
+  if (status != 200) {
+    throw { status, responseText };
+  }
+
+  const data = JSON.parse(responseText);
+  if (data.count === 0) {
+    return [];
+  }
+
+  const itemList = data['@type'] === 'catalog:CatalogPage' ? data.items : data.items[0].items;
+  let versions = itemList.map(item => item.catalogEntry.version);
+  if (!appContrib.dotnetIncludePrerelease) {
+    // If we don't want pre-release, filter out versions which don't have -
+    versions = versions.filter(ver => ver.indexOf("-") === -1);
+  }
+
+  return versions;
+}

--- a/src/providers/dotnet/nugetResolvers/searchAutocompleteServiceResolver.js
+++ b/src/providers/dotnet/nugetResolvers/searchAutocompleteServiceResolver.js
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2019 Ignas Maslinskas. All rights reserved.
+ *  Copyright (c) Peter Flannery. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import appContrib from 'common/appContrib';
+
+// This is an optional NugetV3 api
+// Uses SearchAutocompleteService API
+export async function searchAutocompleteServiceResolver(serviceUrl, packageName) {
+  const httpRequest = require('request-light');
+  const queryUrl = `${serviceUrl}?id=${packageName}&prerelease=${appContrib.dotnetIncludePrerelease}&semVerLevel=2.0.0`;
+  const response = await httpRequest.xhr({ url: queryUrl }); 
+  
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
+
+  const pkg = JSON.parse(response.responseText);
+  if (pkg.totalHits == 0) {
+    throw { status: 404 };
+  } else {
+    return pkg.data.reverse();
+  }
+}
+

--- a/src/providers/dotnet/nugetResolvers/searchQueryServiceResolver.js
+++ b/src/providers/dotnet/nugetResolvers/searchQueryServiceResolver.js
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2019 Ignas Maslinskas. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import appContrib from 'common/appContrib';
+
+// This is a required NugetV3 api
+// Uses SearchQueryService API
+export async function searchQueryServiceResolver(serviceUrl, packageName) {
+  const httpRequest = require('request-light');
+
+  // This could take more than 1 and try to search out of those, but for now just assume that first returned entry will be the most correct.
+  const queryUrl = `${serviceUrl}?q=${packageName}&prerelease=${appContrib.dotnetIncludePrerelease}&semVerLevel=2.0.0&skip=0&take=1`;
+  const response = await httpRequest.xhr({ url: queryUrl });
+
+  if (response.status != 200) {
+    throw {
+      status: response.status,
+      responseText: response.responseText
+    };
+  }
+
+  const { totalHits, data } = JSON.parse(response.responseText);
+  if (totalHits === 0 || data[0].id.toLowerCase() !== packageName.toLowerCase()) {
+    throw { status: 404 };
+  } else {
+    const versions = data[0].versions.map(v => v.version);
+    return versions.reverse();
+  }
+}

--- a/test/unit/providers/dotnet/nugetClient/nugetGetPackageVersions.tests.js
+++ b/test/unit/providers/dotnet/nugetClient/nugetGetPackageVersions.tests.js
@@ -1,4 +1,5 @@
 /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2019 Ignas Maslinskas. All rights reserved.
  *  Copyright (c) Peter Flannery. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
@@ -14,7 +15,7 @@ export default {
   beforeAll: () => {
     // mock require modules
     requestLightMock = {
-      xhr: options => { throw new Error("Not implemented") }
+      xhr: options => { throw new Error('Not implemented') }
     }
 
     mock('request-light', requestLightMock)
@@ -23,42 +24,90 @@ export default {
   // reset all require mocks
   afterAll: () => mock.stopAll,
 
-  "resolves when a package is found": done => {
+  // TODO: Fix this test
+  'rejects when a package is not found': done => {
     const testPackageName = 'test-package';
 
     requestLightMock.xhr = options => {
       return Promise.resolve({
         status: 200,
-        responseText: JSON.stringify({ "totalHits": 1, "data": ["1.0.0"] })
+        responseText: JSON.stringify({ 'totalHits': 0, 'data': [] })
       })
+    }
+
+    nugetGetPackageVersions(testPackageName)
+      .then(results => done(new Error('Should not be called')))
+      .catch(actual => {
+        assert.ok(actual !== null, 'Expected error object not to be null')
+        assert.ok(actual.status === 404, 'Expected error status to be 404')
+        done()
+      })
+  },
+
+  'uses SearchAutocompleteService to resolve package': done => {
+    const testPackageName = 'test-package';
+    const serviceUrl = 'https://test.com/autocomplete';
+
+    requestLightMock.xhr = options => {
+      if (options.url === 'https://api.nuget.org/v3/index.json') {
+        return Promise.resolve({
+          status: 200,
+          responseText: JSON.stringify({
+            resources: [{
+              '@id': serviceUrl,
+              '@type': 'SearchAutocompleteService',
+            }]
+          })
+        })
+      }
+      if (options.url.indexOf(serviceUrl) !== -1) {
+        return Promise.resolve({
+          status: 200,
+          responseText: JSON.stringify({ 'totalHits': 1, 'data': ['1.0.0'] })
+        })
+      }
     }
 
     nugetGetPackageVersions(testPackageName)
       .then(actual => {
-        assert.ok(actual !== null, "Expected results array not to be null")
-        assert.ok(actual.length === 1, "Expected results array to contain 1 item")
+        assert.ok(actual !== null, 'Expected results array not to be null')
+        assert.ok(actual.length === 1, 'Expected results array to contain 1 item')
         done()
       })
-      .catch(error => done(new Error("Should not be called")))
+      .catch(error => done(new Error('Should not be called')))
   },
 
-  "rejects when a package is not found": done => {
+  'uses PackageBaseAddress/3.0.0 to resolve package': done => {
     const testPackageName = 'test-package';
+    const serviceUrl = 'https://test.com/service';
 
     requestLightMock.xhr = options => {
-      return Promise.resolve({
-        status: 200,
-        responseText: JSON.stringify({ "totalHits": 0, "data": [] })
-      })
+      if (options.url === 'https://api.nuget.org/v3/index.json') {
+        return Promise.resolve({
+          status: 200,
+          responseText: JSON.stringify({
+            resources: [{
+              '@id': serviceUrl,
+              '@type': 'PackageBaseAddress/3.0.0',
+            }]
+          })
+        })
+      }
+      if (options.url.indexOf(serviceUrl) !== -1) {
+        return Promise.resolve({
+          status: 200,
+          responseText: JSON.stringify({ 'versions': ['1.0.0'] })
+        })
+      }
     }
 
     nugetGetPackageVersions(testPackageName)
-      .then(results => done(new Error("Should not be called")))
-      .catch(actual => {
-        assert.ok(actual !== null, "Expected error object not to be null")
-        assert.ok(actual.status === 404, "Expected error status to be 404")
+      .then(actual => {
+        assert.ok(actual !== null, 'Expected results array not to be null')
+        assert.ok(actual.length === 1, 'Expected results array to contain 1 item')
         done()
       })
-  }
+      .catch(error => done(new Error('Should not be called')))
+  },
 
 }


### PR DESCRIPTION
Instead of relying on AutocompleteService it can now resolve using multiple ways by looking at nuget feed index and searching for supported services.