### PR TITLE
Return error package in case of failure to parse

### DIFF
--- a/src/commands/factory.js
+++ b/src/commands/factory.js
@@ -188,6 +188,13 @@ export function createPackageNotSupportedCommand(codeLens) {
   );
 }
 
+export function createPackageErrorCommand(codeLens) {
+  return createErrorCommand(
+    'An unexpected error occured',
+    codeLens
+  );
+}
+
 export function createVersionMatchNotFoundCommand(codeLens) {
   return createErrorCommand(
     `Match not found: ${codeLens.package.version}`,

--- a/src/common/packageCodeLens.js
+++ b/src/common/packageCodeLens.js
@@ -53,6 +53,10 @@ export class PackageCodeLens extends CodeLens {
     return this.package.meta.type === type;
   }
 
+  isErrored() {
+    return this.package.meta.tag.isErrored;
+  }
+
   matchesLatestVersion() {
     return this.package.meta.tag && this.package.meta.tag.isLatestVersion;
   }

--- a/src/common/packageGeneration.js
+++ b/src/common/packageGeneration.js
@@ -43,6 +43,18 @@ export function createInvalidVersion(name, version, type) {
   );
 }
 
+export function createPackageErrored(name, version, type) {
+  return createPackage(
+    name,
+    version, {
+      type,
+      tag: {
+        isErrored: true
+      }
+    }
+  );
+}
+
 export function createPackage(name, version, meta, customGenerateVersion) {
   return {
     name,

--- a/src/providers/dotnet/dotnetCodeLensProvider.js
+++ b/src/providers/dotnet/dotnetCodeLensProvider.js
@@ -47,6 +47,10 @@ export class DotNetCodeLensProvider extends AbstractCodeLensProvider {
   }
 
   evaluateCodeLens(codeLens) {
+    // check if error occured
+    if (codeLens.isErrored())
+      return CommandFactory.createPackageErrorCommand(codeLens);
+
     // check if this package was found
     if (codeLens.packageNotFound())
       return CommandFactory.createPackageNotFoundCommand(codeLens);

--- a/src/providers/dotnet/dotnetPackageParser.js
+++ b/src/providers/dotnet/dotnetPackageParser.js
@@ -81,7 +81,11 @@ export function dotnetPackageParser(name, requestedVersion, appContrib) {
       }
 
       console.error(error);
-      throw error;
+      return PackageFactory.createPackageErrored(
+        name,
+        requestedVersion,
+        'nuget'
+      )
     });
 
 }


### PR DESCRIPTION
Instead of just erroring out return a error type package. This means that the extension still can function for other packages that did not fail.