### PR TITLE
Fix latest version being reported incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.25.6
+  - Dotnet: Fix incorrect latest versions being reported when semver single section has more than 1 digit.
+
 # 0.25.3
 
   - Dotnet: Do not rely on `@type` for `RegistrationsBaseUrl`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Ignas Maslinskas",
   "license": "MIT",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "publisher": "Hoffs",
   "displayName": "Version Lens",
   "icon": "images/logo.png",

--- a/src/common/versionUtils.js
+++ b/src/common/versionUtils.js
@@ -308,6 +308,10 @@ export function buildTagsFromVersionMap(versionMap, requestedVersion) {
   const isRequestedVersionValid = semver.validRange(requestedVersion);
   const versionMatchNotFound = !versionMap.maxSatisfyingVersion;
 
+  // properly sort based on semver
+  versionMap.releases = semver.sort(versionMap.releases || []).reverse();
+  versionMap.taggedVersions.sort((a, b) => semver.compare(a.version, b.version)).reverse();
+
   // create the latest release entry
   const latestEntry = {
     name: "latest",


### PR DESCRIPTION
Due to responses not being sorted and or merged, the order when checking the latest version was not correct, so version at 0 might not be actually latest version. This should fix by making sure to sort the entire arrays before making assumptions.

Fixes #14